### PR TITLE
Corrected 'character' leaking into global scope.

### DIFF
--- a/lib/CSSTree.js
+++ b/lib/CSSTree.js
@@ -85,6 +85,7 @@ CSSTree.prototype = {
 		var self = this,
 			position = new CSSTree.Position( self.i + 1 ),
 			selector = '',
+			character,
 			parts = [], nested = null, part = '',
 			peek, branch;
 
@@ -284,7 +285,7 @@ CSSTree.prototype = {
 	nested: function( atrule, position ) {
 		var self = this,
 			string = '',
-			peek, index, rule, subPosition,
+			peek, index, rule, subPosition, character,
 			block = atrule.trim()[ 0 ] == '@' ?
 				new CSSTree.AtRule( atrule, position ) :
 				new CSSTree.Selector( atrule, null, position );
@@ -420,18 +421,18 @@ CSSTree.prototype = {
 
 	// Marks the line & character for the character position passed
 	_charPosition: function( pos ) {
-		var self = this, line = self._newlines.length, chracter = 0;
+		var self = this, line = self._newlines.length, character = 0;
 
 		while ( line-- ) {
 			if ( pos > self._newlines[ line ] ) {
-				chracter = self._newlines[ line ] + 1;
+				character = self._newlines[ line ] + 1;
 				break;
 			}
 		}
 		
 		return {
 			line: line + 2,
-			character: ( pos + 1 ) - chracter
+			character: ( pos + 1 ) - character
 		};
 	}
 


### PR DESCRIPTION
My test suite for Behaviour Assertion Sheets caught a couple instances of the `character` variable leaking into global scope, due to missing declarations at the top of their respective functions.

I've corrected this issue, and fixed an additional typo I found in CSSTree.js. (`chracter`)

If you decide to merge, it'd be awesome if you pushed an npm update too! :)

(Thanks again for CSSTree, it's helped me enormously!)
