### PR TITLE
Fixes issue with duplicated escape characters in nested blocks.

### DIFF
--- a/lib/CSSTree.js
+++ b/lib/CSSTree.js
@@ -297,6 +297,7 @@ CSSTree.prototype = {
 			// Escaped string
 			if ( self.c == '\\' ) {
 				string += self.c + self.css[ ++self.i ];
+				continue;
 			}
 			// Comment
 			if ( self.c == '/' && peek == '*' ) {


### PR DESCRIPTION
In Behaviour Assertion Sheets, I allow the use of regex in the sheet, which caused me to find an issue where escape characters in nested blocks have their escape sequences duplicated. Here's a test case:

```
@all {
    /* Testing for a known problem with escape sequences */
    selector {
        test: /a\/(b)/;
    }
}
```

In this case, `/a\/(b)/` becomes `/a\/\(b)/`, which breaks the regular expression. I imagine that other values in CSS could possibly be affected, although I haven't found a good example yet.

Fixing the issue was a simple matter of skipping to the next loop iteration with `continue` after the escape sequence had been determined.

I've verified that the test suite still passes locally.

If you could push this to npm (if you accept and merge it) that'd be awesome!
