### PR TITLE
Inline Comments

### DIFF
--- a/lib/CSSTree.js
+++ b/lib/CSSTree.js
@@ -300,6 +300,8 @@ CSSTree.prototype = {
 			block = atrule.trim()[ 0 ] == '@' ?
 				new CSSTree.AtRule( atrule, position ) :
 				new CSSTree.Selector( atrule, null, position );
+		
+		self._currentBranchStack.push(block);
 
 		for ( ; ++self.i < self.length; ) {
 			self.c = self.css[ self.i ];
@@ -381,8 +383,7 @@ CSSTree.prototype = {
 					// Parse out value parts and add to rules
 					block.rules.push( rule );
 				}
-				console.log(self);
-				console.log(self._currentBranchStack);
+				
 				self._currentBranchStack.pop();
 				block.position.markEnd( self.i + 1, false );
 				return block;

--- a/lib/CSSTree.js
+++ b/lib/CSSTree.js
@@ -350,7 +350,6 @@ CSSTree.prototype = {
 				// Travel down the tree
 				subPosition = new CSSTree.Position( self.i - string.length, position );
 				block.branches.push( self.nested( string, subPosition ) );
-				self._currentBranchStack.push( block.branches[ block.branches.length - 1 ] );
 				string = '';
 			}
 			// Seek

--- a/lib/CSSTree.js
+++ b/lib/CSSTree.js
@@ -297,6 +297,7 @@ CSSTree.prototype = {
 			// Escaped string
 			if ( self.c == '\\' ) {
 				string += self.c + self.css[ ++self.i ];
+				continue;
 			}
 			// Comment
 			if ( self.c == '/' && peek == '*' ) {

--- a/lib/CSSTree.js
+++ b/lib/CSSTree.js
@@ -16,6 +16,8 @@ function CSSTree( css ) {
 	self.i = -1;
 	self.length = self.css.length;
 	self.branches = [];
+	
+	self._currentBranchStack = [ self ];
 
 	// Positional setup
 	self._newlines = [];
@@ -61,7 +63,8 @@ CSSTree.prototype = {
 		var self = this,
 			position = new CSSTree.Position( self.i + 1 ),
 			comment = '',
-			peek = '';
+			peek = '',
+			branch = ( self._currentBranchStack || [] ).slice( -1 ).pop() || self;
 
 		nested = nested || false;
 		for ( ; ++self.i < self.length; ) {
@@ -70,8 +73,14 @@ CSSTree.prototype = {
 
 			// End of comment
 			if ( self.c == '*' && peek == '/' ) {
-				return self.branches.push(
-					new CSSTree.Comment( comment + '*/', nested, position.markEnd( ++self.i + 1 ) )
+				if (!branch.branches) {
+					branch.branches = [];
+				}
+				
+				return branch.branches.push(
+					new CSSTree.Comment(
+						comment + '*/', nested, position.markEnd( ++self.i + 1 ) 
+					)
 				);
 			}
 			else {
@@ -87,7 +96,7 @@ CSSTree.prototype = {
 			selector = '',
 			character,
 			parts = [], nested = null, part = '',
-			peek, branch;
+			peek, branch, newBranch;
 
 		for ( ; ++self.i < self.length; ) {
 			self.c = self.css[ self.i ];
@@ -101,19 +110,21 @@ CSSTree.prototype = {
 			}
 			// Atrule
 			else if ( self.c == ';' ) {
-				return self.branches.push(
-					new CSSTree.AtRule( selector, position.markEnd( self.i ) )
-				);
+				newBranch = new CSSTree.AtRule( selector, position.markEnd( self.i ) );
+				self._currentBranchStack.push( newBranch );
+				return self.branches.push( newBranch );
 			}
 			// Media atrule
 			else if ( self.c == '{' && selector.trim()[ 0 ] == '@' ) {
-				branch = self.nested( selector, position );
+				self._currentBranchStack.push( branch = self.nested( selector, position ) );
 				branch.position = position.markEnd( self.i + 1 );
 				return self.branches.push( branch );
 			}
 			// Selector for ruleset
 			else if ( self.c == '{' ) {
-				branch = new CSSTree.Selector( selector, self.rules( position ), position );
+				self._currentBranchStack.push(
+					branch = new CSSTree.Selector( selector, self.rules( position ), position )
+				);
 				position.markEnd( self.i + 1 );
 				return self.branches.push( branch );
 			}
@@ -337,6 +348,7 @@ CSSTree.prototype = {
 				// Travel down the tree
 				subPosition = new CSSTree.Position( self.i - string.length, position );
 				block.branches.push( self.nested( string, subPosition ) );
+				self._currentBranchStack.push( block.branches[ block.branches.length - 1 ] );
 				string = '';
 			}
 			// Seek
@@ -369,7 +381,9 @@ CSSTree.prototype = {
 					// Parse out value parts and add to rules
 					block.rules.push( rule );
 				}
-
+				console.log(self);
+				console.log(self._currentBranchStack);
+				self._currentBranchStack.pop();
 				block.position.markEnd( self.i + 1, false );
 				return block;
 			}

--- a/test/test-AtRule.js
+++ b/test/test-AtRule.js
@@ -68,6 +68,6 @@ munit( 'AtRule', {
 			atrule.breakdown();
 			assert.deepEqual( object.name, atrule.parts, object.parts );
 		});
-	},
+	}
 
 });

--- a/test/test-CSSTree.js
+++ b/test/test-CSSTree.js
@@ -23,6 +23,6 @@ munit( 'CSSTree', { priority: 1.0 }, {
 			.isFunction( 'Comment', CSSTree.Comment )
 			.isFunction( 'AtRule', CSSTree.AtRule )
 			.isFunction( 'Rule', CSSTree.Rule );
-	},
+	}
 
 });

--- a/test/test-Rule.js
+++ b/test/test-Rule.js
@@ -66,6 +66,6 @@ munit( 'Rule', {
 			rule.breakdown();
 			assert.deepEqual( object.name, rule.parts, object.parts );
 		});
-	},
+	}
 
 });

--- a/test/test-Selector.js
+++ b/test/test-Selector.js
@@ -128,6 +128,6 @@ munit( 'Selector', {
 			selector.breakdown();
 			assert.deepEqual( object.name, selector.parts, object.parts );
 		});
-	},
+	}
 
 });

--- a/test/test-files.js
+++ b/test/test-files.js
@@ -60,6 +60,6 @@ munit( 'Files', { priority: munit.PRIORITY_LOW }, {
 
 			assert.deepEqual( name, branches, match );
 		});
-	},
+	}
 
 });


### PR DESCRIPTION
I had always assumed that CSSTree would place comments in the AST according to where they fell in the document, and was a little surprised when I discovered this wasn't the case.

I wasn't sure whether the comments were left out-of-band for a reason.

In any case, I've made a change that would bring them inline, submitted for your consideration. Regardless of whether you decide to merge this PR, or attack this your own way, it'd be nice for comments to be built into the AST like any other construct in the document.

The test suite passes locally without issue.
